### PR TITLE
Multiple views exposed filter handling bugfix.

### DIFF
--- a/js/modules/views/ajax_view.js
+++ b/js/modules/views/ajax_view.js
@@ -12,7 +12,7 @@
   Drupal.views.ajaxView.prototype.attachExposedFormAjax = function () {
     var that = this;
     this.exposedFormAjax = [];
-    $('button[type=submit], input[type=submit], input[type=image]', this.$exposed_form).not('[data-drupal-selector=edit-reset]').each(function (index) {
+    $('button[type=submit], input[type=submit], input[type=image]').not('[data-drupal-selector=edit-reset]').each(function (index) {
       var self_settings = $.extend({}, that.element_settings, {
         base: $(this).attr('id'),
         element: this


### PR DESCRIPTION
When multiple views exposed filters, in this specific bug case exo exposed filters, this.$exposed_form context would return undefined.

This would cause only one exposed filter to be extended, and ajax would fail on others within the same page.

For example an exposed filter, and that same exposed filter higher on the page.

This does resolve the issue, and perhaps is the best solution, as an exposed filter could be anywhere within the html body.